### PR TITLE
Int fflonk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,10 @@ members = [
     "bw6",
     "mipp",
 ]
+
+[patch.crates-io]
+ark-std = { git = "https://github.com/arkworks-rs/std" }
+ark-ff = { git = "https://github.com/arkworks-rs/algebra", rev = "d6365c3" }
+ark-ec = { git = "https://github.com/arkworks-rs/algebra", rev = "d6365c3" }
+ark-poly = { git = "https://github.com/arkworks-rs/algebra", rev = "d6365c3" }
+ark-serialize = { git = "https://github.com/arkworks-rs/algebra", rev = "d6365c3" }

--- a/bw6/Cargo.toml
+++ b/bw6/Cargo.toml
@@ -10,11 +10,12 @@ categories = ["cryptography"]
 [dependencies]
 ark-ff = { version = "0.3", default-features = false }
 ark-ec = { version = "0.3", default-features = false }
-ark-serialize = { version = "0.3", default-features = false, features = [ "derive" ] }
-ark-bls12-377 = { version = "0.3", default-features = false, features = [ "curve" ] }
-ark-bw6-761 = { version = "0.3", default-features = false }
+ark-serialize = { version = "0.3", default-features = false, features = ["derive"] }
+ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves", version = "0.3", default-features = false, features = ["curve"] }
+ark-bw6-761 = { git = "https://github.com/arkworks-rs/curves", version = "0.3", default-features = false }
 ark-std = { version = "0.3", default-features = false }
 ark-poly = { version = "0.3", default-features = false }
+fflonk = { git = "https://github.com/w3f/fflonk" }
 
 rand = "0.8"
 merlin = "3.0"

--- a/bw6/src/keyset.rs
+++ b/bw6/src/keyset.rs
@@ -88,8 +88,8 @@ impl Keyset {
 
     pub fn commit(&self, kzg_pk: &KzgCommitterKey<ark_bw6_761::G1Affine>) -> KeysetCommitment {
         assert!(self.domain.size() <= kzg_pk.max_degree() + 1);
-        let pks_x_comm= NewKzgBw6::commit(kzg_pk, &self.pks_polys[0]).0.into_affine();
-        let pks_y_comm= NewKzgBw6::commit(kzg_pk, &self.pks_polys[1]).0.into_affine();
+        let pks_x_comm= NewKzgBw6::commit(kzg_pk, &self.pks_polys[0]).0;
+        let pks_y_comm= NewKzgBw6::commit(kzg_pk, &self.pks_polys[1]).0;
         KeysetCommitment {
             pks_comm: (pks_x_comm, pks_y_comm),
             domain: self.domain,

--- a/bw6/src/kzg/mod.rs
+++ b/bw6/src/kzg/mod.rs
@@ -5,7 +5,7 @@
 //! proposed by Kate, Zaverucha, and Goldberg ([KZG11](http://cacr.uwaterloo.ca/techreports/2010/cacr2010-10.pdf)).
 //! This construction achieves extractability in the algebraic group model (AGM).
 
-use ark_ec::msm::{FixedBaseMSM, VariableBaseMSM};
+use ark_ec::msm::{FixedBase, VariableBase};
 use ark_ec::{AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::{One, PrimeField, UniformRand, Zero};
 use ark_poly::UVPolynomial;
@@ -124,12 +124,12 @@ impl<E, P> KZG10<E, P>
 
         let powers_of_beta = utils::powers(beta, max_degree);
 
-        let window_size = FixedBaseMSM::get_mul_window_size(max_degree + 1);
+        let window_size = FixedBase::get_mul_window_size(max_degree + 1);
 
         let scalar_bits = E::Fr::size_in_bits();
         let g_time = start_timer!(|| "Generating powers of G");
-        let g_table = FixedBaseMSM::get_window_table(scalar_bits, window_size, g);
-        let powers_of_g = FixedBaseMSM::multi_scalar_mul::<E::G1Projective>(
+        let g_table = FixedBase::get_window_table(scalar_bits, window_size, g);
+        let powers_of_g = FixedBase::msm::<E::G1Projective>(
             scalar_bits,
             window_size,
             &g_table,
@@ -168,7 +168,7 @@ impl<E, P> KZG10<E, P>
             skip_leading_zeros_and_convert_to_bigints(polynomial);
 
         let msm_time = start_timer!(|| "MSM to compute commitment to plaintext poly");
-        let commitment = VariableBaseMSM::multi_scalar_mul(
+        let commitment = VariableBase::msm(
             &powers.0[num_leading_zeros..],
             &plain_coeffs,
         );
@@ -204,7 +204,7 @@ impl<E, P> KZG10<E, P>
             skip_leading_zeros_and_convert_to_bigints(witness_polynomial);
 
         let witness_comm_time = start_timer!(|| "Computing commitment to witness polynomial");
-        let w = VariableBaseMSM::multi_scalar_mul(
+        let w = VariableBase::msm(
             &powers.0[num_leading_zeros..],
             &witness_coeffs,
         );
@@ -485,6 +485,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_batch_verification() {
         let rng = &mut test_rng();
 

--- a/bw6/src/kzg/mod.rs
+++ b/bw6/src/kzg/mod.rs
@@ -514,9 +514,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         let t_kzg_batch_opening = start_timer!(|| "batched KZG opening");
-        let (total_c, total_w) =
-            KzgBw6::aggregate_openings(&pvk, &cs, &xs, &ys, &proofs, rng);
-        assert!(KzgBw6::batch_check_aggregated(&pvk, total_c, total_w));
+        assert!(KzgBw6::batch_check(&pvk, &cs, &xs, &ys, &proofs, rng));
         end_timer!(t_kzg_batch_opening);
     }
 

--- a/bw6/src/piop/affine_addition.rs
+++ b/bw6/src/piop/affine_addition.rs
@@ -118,6 +118,8 @@ impl VerifierProtocol for AffineAdditionEvaluations {
     type C2 = ();
     type C1 = PartialSumsCommitments;
 
+    const POLYS_OPENED_AT_ZETA: usize = 5;
+
     fn restore_commitment_to_linearization_polynomial(&self,
                                                       phi: Fr,
                                                       zeta_minus_omega_inv: Fr,

--- a/bw6/src/piop/bit_counting.rs
+++ b/bw6/src/piop/bit_counting.rs
@@ -1,4 +1,4 @@
-use ark_poly::{Evaluations, Radix2EvaluationDomain, EvaluationDomain, Polynomial};
+use ark_poly::{Evaluations, Polynomial};
 use ark_bw6_761::Fr;
 use crate::Bitmask;
 use ark_ff::{Zero, One};
@@ -8,7 +8,6 @@ use ark_poly::univariate::DensePolynomial;
 use ark_std::io::{Read, Write};
 use ark_serialize::{CanonicalSerialize, CanonicalDeserialize, SerializationError};
 use crate::domains::Domains;
-use crate::utils::LagrangeEvaluations;
 
 
 // This "gadget" is used in the 'counting' scheme to constraint the number of set bits in the bitmask.

--- a/bw6/src/piop/bitmask_packing.rs
+++ b/bw6/src/piop/bitmask_packing.rs
@@ -154,7 +154,7 @@ impl VerifierProtocol for SuccinctAccountableRegisterEvaluations {
     type C1 = PartialSumsAndBitmaskCommitments;
     type C2 = BitmaskPackingCommitments;
 
-
+    const POLYS_OPENED_AT_ZETA: usize = 8;
 
     fn restore_commitment_to_linearization_polynomial(&self,
                                                       phi: Fr,

--- a/bw6/src/piop/counting.rs
+++ b/bw6/src/piop/counting.rs
@@ -163,7 +163,6 @@ mod tests {
     use crate::tests::{random_bits, random_pks};
     use crate::NewKzgBw6;
     use fflonk::pcs::{PCS, PcsParams};
-    use ark_ec::ProjectiveCurve;
 
     #[test]
     fn test_polynomial_ordering() {
@@ -184,7 +183,7 @@ mod tests {
         let zeta = Fr::rand(rng);
 
         let actual_commitments = scheme.get_register_polynomials_to_commit1()
-            .commit(|p| NewKzgBw6::commit(&kzg_params.ck(), &p).0.into_affine()).as_vec();
+            .commit(|p| NewKzgBw6::commit(&kzg_params.ck(), &p).0).as_vec();
         let actual_evaluations = scheme.evaluate_register_polynomials(zeta).as_vec();
         let polynomials = scheme.get_register_polynomials_to_open();
 
@@ -196,7 +195,7 @@ mod tests {
 
         let expected_commitments = polynomials.iter()
             .skip(2) // keyset commitment is publicly known
-            .map(|p| NewKzgBw6::commit(&kzg_params.ck(), &p).0.into_affine())
+            .map(|p| NewKzgBw6::commit(&kzg_params.ck(), &p).0)
             .collect::<Vec<_>>();
         assert_eq!(actual_commitments, expected_commitments);
     }

--- a/bw6/src/piop/counting.rs
+++ b/bw6/src/piop/counting.rs
@@ -131,6 +131,8 @@ impl VerifierProtocol for CountingEvaluations {
     type C1 = CountingCommitments;
     type C2 = ();
 
+    const POLYS_OPENED_AT_ZETA: usize = 7;
+
     fn restore_commitment_to_linearization_polynomial(&self, phi: Fr, zeta_minus_omega_inv: Fr, commitments: &Self::C1, _extra_commitments: &Self::C2) -> G1Projective {
         let powers_of_phi = utils::powers(phi, 6);
         let partial_sums_commitments = &commitments.affine_addition_commitments.partial_sums;

--- a/bw6/src/piop/mod.rs
+++ b/bw6/src/piop/mod.rs
@@ -147,6 +147,8 @@ pub trait VerifierProtocol {
     type C1: RegisterCommitments; // commitments to ProverProtocol::P1
     type C2: RegisterCommitments; // commitments to ProverProtocol::P2
 
+    const POLYS_OPENED_AT_ZETA: usize;
+
     fn restore_commitment_to_linearization_polynomial(
         &self,
         phi: Fr,

--- a/bw6/src/prover.rs
+++ b/bw6/src/prover.rs
@@ -77,7 +77,7 @@ impl Prover {
         let mut protocol = P::init(self.domains.clone(), bitmask, self.keyset.clone());
         let partial_sums_polynomials = protocol.get_register_polynomials_to_commit1();
         let partial_sums_commitments = partial_sums_polynomials.commit(
-            |p| NewKzgBw6::commit(&self.kzg_pk, &p).0.into_affine()
+            |p| NewKzgBw6::commit(&self.kzg_pk, &p).0
         );
 
         transcript.append_register_commitments(&partial_sums_commitments);
@@ -88,7 +88,7 @@ impl Prover {
         // let acc_registers = D::wrap(registers, b, r);
         let acc_register_polynomials = protocol.get_register_polynomials_to_commit2(r);
         let acc_register_commitments = acc_register_polynomials.commit(
-            |p| NewKzgBw6::commit(&self.kzg_pk, &p).0.into_affine()
+            |p| NewKzgBw6::commit(&self.kzg_pk, &p).0
         );
         transcript.append_2nd_round_register_commitments(&acc_register_commitments);
 
@@ -96,7 +96,7 @@ impl Prover {
         // compute and commit to the quotient polynomial.
         let phi = transcript.get_constraints_aggregation_challenge();
         let q_poly = protocol.compute_quotient_polynomial(phi, self.keyset.domain);
-        let q_comm = NewKzgBw6::commit(&self.kzg_pk, &q_poly).0.into_affine();
+        let q_comm = NewKzgBw6::commit(&self.kzg_pk, &q_poly).0;
         transcript.append_quotient_commitment(&q_comm);
 
         // 4. Receive the evaluation point,

--- a/bw6/src/prover.rs
+++ b/bw6/src/prover.rs
@@ -2,9 +2,8 @@ use ark_bw6_761::BW6_761;
 use ark_poly::{Polynomial, EvaluationDomain};
 use merlin::Transcript;
 
-use crate::{KzgBw6, Proof, Bitmask, PublicInput, SimpleProof, PackedProof, CountingProof, AccountablePublicInput, CountingPublicInput, KeysetCommitment, kzg};
+use crate::{Proof, Bitmask, PublicInput, SimpleProof, PackedProof, CountingProof, AccountablePublicInput, CountingPublicInput, KeysetCommitment, NewKzgBw6};
 use crate::transcript::ApkTranscript;
-use crate::kzg::ProverKey;
 use crate::piop::ProverProtocol;
 use crate::piop::RegisterPolynomials;
 use crate::piop::packed::PackedRegisterBuilder;
@@ -13,12 +12,15 @@ use crate::piop::counting::CountingScheme;
 use crate::keyset::Keyset;
 use ark_ec::ProjectiveCurve;
 use crate::domains::Domains;
+use fflonk::pcs::{PCS, PcsParams};
+use fflonk::pcs::kzg::urs::URS;
+use fflonk::pcs::kzg::params::KzgCommitterKey;
 
 
 pub struct Prover {
     domains: Domains,
     keyset: Keyset,
-    kzg_pk: ProverKey<BW6_761>,
+    kzg_pk: KzgCommitterKey<ark_bw6_761::G1Affine>,
     preprocessed_transcript: Transcript,
 }
 
@@ -29,13 +31,13 @@ impl Prover {
         mut keyset: Keyset,
         keyset_comm: &KeysetCommitment,
         // prover needs both KZG pk and vk, as it commits to the latter to bind the srs
-        kzg_params: kzg::Params<BW6_761>,
+        kzg_params: URS<BW6_761>,
         mut empty_transcript: Transcript,
     ) -> Self {
         let domains = Domains::new(keyset.domain.size());
 
-        assert!(kzg_params.fits(keyset.domain.size())); // SRS contains enough elements
-        empty_transcript.set_protocol_params(&keyset.domain, &kzg_params.get_vk());
+        // assert!(kzg_params.fits(keyset.domain.size())); // SRS contains enough elements
+        empty_transcript.set_protocol_params(&keyset.domain, &kzg_params.raw_vk());
         empty_transcript.set_keyset_commitment(&keyset_comm);
 
         keyset.amplify();
@@ -43,7 +45,7 @@ impl Prover {
         Self {
             domains,
             keyset,
-            kzg_pk: kzg_params.get_pk(),
+            kzg_pk: kzg_params.ck(),
             preprocessed_transcript: empty_transcript,
         }
     }
@@ -75,7 +77,7 @@ impl Prover {
         let mut protocol = P::init(self.domains.clone(), bitmask, self.keyset.clone());
         let partial_sums_polynomials = protocol.get_register_polynomials_to_commit1();
         let partial_sums_commitments = partial_sums_polynomials.commit(
-            |p| KzgBw6::commit(&self.kzg_pk, &p)
+            |p| NewKzgBw6::commit(&self.kzg_pk, &p).0.into_affine()
         );
 
         transcript.append_register_commitments(&partial_sums_commitments);
@@ -86,7 +88,7 @@ impl Prover {
         // let acc_registers = D::wrap(registers, b, r);
         let acc_register_polynomials = protocol.get_register_polynomials_to_commit2(r);
         let acc_register_commitments = acc_register_polynomials.commit(
-            |p| KzgBw6::commit(&self.kzg_pk, &p)
+            |p| NewKzgBw6::commit(&self.kzg_pk, &p).0.into_affine()
         );
         transcript.append_2nd_round_register_commitments(&acc_register_commitments);
 
@@ -94,7 +96,7 @@ impl Prover {
         // compute and commit to the quotient polynomial.
         let phi = transcript.get_constraints_aggregation_challenge();
         let q_poly = protocol.compute_quotient_polynomial(phi, self.keyset.domain);
-        let q_comm = KzgBw6::commit(&self.kzg_pk, &q_poly);
+        let q_comm = NewKzgBw6::commit(&self.kzg_pk, &q_poly).0.into_affine();
         transcript.append_quotient_commitment(&q_comm);
 
         // 4. Receive the evaluation point,
@@ -113,12 +115,12 @@ impl Prover {
         // open the aggregated polynomial at the evaluation point,
         // and the linearization polynomial at the shifted evaluation point,
         // and commit to the opening proofs.
-        let nu = transcript.get_kzg_aggregation_challenge();
         let mut register_polynomials = protocol.get_register_polynomials_to_open();
         register_polynomials.push(q_poly);
-        let w_poly = KzgBw6::aggregate_polynomials(nu, &register_polynomials);
-        let w_at_zeta_proof = KzgBw6::open(&self.kzg_pk, &w_poly, zeta);
-        let r_at_zeta_omega_proof = KzgBw6::open(&self.kzg_pk, &r_poly, zeta_omega);
+        let nus = transcript.get_kzg_aggregation_challenges(register_polynomials.len());
+        let w_poly = fflonk::aggregation::single::aggregate_polys(&register_polynomials, &nus);
+        let w_at_zeta_proof = NewKzgBw6::open(&self.kzg_pk, &w_poly, zeta);
+        let r_at_zeta_omega_proof = NewKzgBw6::open(&self.kzg_pk, &r_poly, zeta_omega);
 
         // Finally, compose the proof.
         let proof = Proof {

--- a/bw6/src/setup.rs
+++ b/bw6/src/setup.rs
@@ -1,9 +1,12 @@
 use ark_bw6_761::{BW6_761, Fr};
 use ark_ff::{FftField, FftParameters};
-use crate::{kzg, KzgBw6};
+use crate::NewKzgBw6;
 use rand::Rng;
+use fflonk::pcs::PCS;
+use fflonk::pcs::kzg::urs::URS;
 
-pub fn generate_for_keyset<R: Rng>(keyset_size: usize, rng: &mut R) -> kzg::Params<BW6_761> {
+
+pub fn generate_for_keyset<R: Rng>(keyset_size: usize, rng: &mut R) -> URS<BW6_761> {
     let required_domain_size = keyset_size + 1; // additional slot is occupied by affine addition accumulator initial value
     // as we use radix 2 domains
     let required_domain_size = required_domain_size.next_power_of_two();
@@ -11,7 +14,7 @@ pub fn generate_for_keyset<R: Rng>(keyset_size: usize, rng: &mut R) -> kzg::Para
     generate_for_domain(log_domain_size, rng)
 }
 
-pub fn generate_for_domain<R: Rng>(log_domain_size: u32, rng: &mut R) -> kzg::Params<BW6_761> {
+pub fn generate_for_domain<R: Rng>(log_domain_size: u32, rng: &mut R) -> URS<BW6_761> {
     let domain_size = 2usize.pow(log_domain_size);
     // to operate with polynomials of degree up to 4 * domain_size, there should exist a domain of size 4 * domain_size
     assert!(log_domain_size + 2 <= <Fr as FftField>::FftParams::TWO_ADICITY, "not enough 2-adicity in ark_bw6_761::Fr");
@@ -19,8 +22,8 @@ pub fn generate_for_domain<R: Rng>(log_domain_size: u32, rng: &mut R) -> kzg::Pa
     // the highest degree polynomial prover needs to commit is the quotient q=aggregate_constraint_polynomial/vanishing_polynomial
     // as the highest constraint degree is 4n-3, deg(q) = 3n-3
     let max_poly_degree = highest_degree_to_commit(domain_size);
-    let kzg_params = KzgBw6::setup(max_poly_degree, rng);
-    assert!(kzg_params.fits(domain_size));
+    let kzg_params = NewKzgBw6::setup(max_poly_degree, rng);
+    // assert!(kzg_params.fits(domain_size));
     kzg_params
 }
 
@@ -28,8 +31,8 @@ fn highest_degree_to_commit(domain_size: usize) -> usize {
     3 * domain_size - 3
 }
 
-impl kzg::Params<BW6_761> {
-    pub fn fits(&self, domain_size: usize) -> bool {
-        highest_degree_to_commit(domain_size) <= self.get_pk().max_degree()
-    }
-}
+// impl kzg::Params<BW6_761> {
+//     pub fn fits(&self, domain_size: usize) -> bool {
+//         highest_degree_to_commit(domain_size) <= self.get_pk().max_degree()
+//     }
+// }

--- a/bw6/src/verifier.rs
+++ b/bw6/src/verifier.rs
@@ -1,12 +1,11 @@
-use ark_poly::{Radix2EvaluationDomain, EvaluationDomain};
+use ark_poly::Radix2EvaluationDomain;
 use ark_bw6_761::{BW6_761, Fr};
 use ark_ec::ProjectiveCurve;
 use ark_std::{end_timer, start_timer};
 use merlin::{Transcript, TranscriptRng};
 
-use crate::{endo, Proof, utils, KzgBw6, RegisterCommitments, PublicInput, AccountablePublicInput, CountingPublicInput, SimpleProof, PackedProof, CountingProof, KeysetCommitment};
+use crate::{endo, Proof, utils, RegisterCommitments, PublicInput, AccountablePublicInput, CountingPublicInput, SimpleProof, PackedProof, CountingProof, KeysetCommitment, NewKzgBw6};
 use crate::transcript::ApkTranscript;
-use crate::kzg::{VerifierKey, PreparedVerifierKey};
 use crate::fsrng::fiat_shamir_rng;
 use crate::piop::bitmask_packing::{SuccinctAccountableRegisterEvaluations, BitmaskPackingCommitments};
 use crate::piop::{VerifierProtocol, RegisterEvaluations};
@@ -14,11 +13,14 @@ use crate::piop::affine_addition::{AffineAdditionEvaluations, PartialSumsCommitm
 use crate::piop::basic::AffineAdditionEvaluationsWithoutBitmask;
 use crate::utils::LagrangeEvaluations;
 use crate::piop::counting::{CountingEvaluations, CountingCommitments};
+use fflonk::aggregation::single::aggregate_claims_multiexp;
+use fflonk::pcs::kzg::KzgOpening;
+use fflonk::pcs::kzg::params::{KzgVerifierKey, RawKzgVerifierKey};
 
 
 pub struct Verifier {
     domain: Radix2EvaluationDomain<Fr>,
-    kzg_pvk: PreparedVerifierKey<BW6_761>,
+    kzg_pvk: KzgVerifierKey<BW6_761>,
     pks_comm: KeysetCommitment,
     preprocessed_transcript: Transcript,
 }
@@ -27,7 +29,7 @@ struct Challenges {
     r: Fr,
     phi: Fr,
     zeta: Fr,
-    nu: Fr,
+    nus: Vec<Fr>,
 }
 
 
@@ -38,7 +40,7 @@ impl Verifier {
         proof: &SimpleProof,
     ) -> bool {
         assert_eq!(public_input.bitmask.size(), self.pks_comm.keyset_size);
-        let (challenges, mut fsrng) = self.restore_challenges(public_input, proof);
+        let (challenges, mut fsrng) = self.restore_challenges(public_input, proof, 5);
         let evals_at_zeta = utils::lagrange_evaluations(challenges.zeta, self.domain);
 
         let t_linear_accountability = start_timer!(|| "linear accountability check");
@@ -70,7 +72,7 @@ impl Verifier {
         proof: &PackedProof,
     ) -> bool {
         assert_eq!(public_input.bitmask.size(), self.pks_comm.keyset_size);
-        let (challenges, mut fsrng) = self.restore_challenges(public_input, proof);
+        let (challenges, mut fsrng) = self.restore_challenges(public_input, proof, 8);
         let evals_at_zeta = utils::lagrange_evaluations(challenges.zeta, self.domain);
 
         self.validate_evaluations::<
@@ -92,7 +94,7 @@ impl Verifier {
         proof: &CountingProof,
     ) -> bool {
         assert!(public_input.count > 0);
-        let (challenges, mut fsrng) = self.restore_challenges(public_input, proof);
+        let (challenges, mut fsrng) = self.restore_challenges(public_input, proof, 7);
         let evals_at_zeta = utils::lagrange_evaluations(challenges.zeta, self.domain);
         let count = Fr::from(public_input.count as u16);
 
@@ -139,7 +141,7 @@ impl Verifier {
 
 
         // Aggregate the commitments to be opened in \zeta, using the challenge \nu.
-        let t_multiexp = start_timer!(|| "aggregated commitment");
+        let t_aggregate_claims = start_timer!(|| "aggregate evaluation claims in zeta");
         let mut commitments = vec![
             self.pks_comm.pks_comm.0,
             self.pks_comm.pks_comm.1,
@@ -147,38 +149,39 @@ impl Verifier {
         commitments.extend(proof.register_commitments.as_vec());
         commitments.extend(proof.additional_commitments.as_vec());
         commitments.push(proof.q_comm);
-        let w_comm = KzgBw6::aggregate_commitments(challenges.nu, &commitments);
-        end_timer!(t_multiexp);
 
-
-        let t_opening_points = start_timer!(|| "aggregated evaluation");
         let mut register_evals = proof.register_evaluations.as_vec();
         register_evals.push(proof.q_zeta);
-        let w_at_zeta = KzgBw6::aggregate_values(challenges.nu, &register_evals);
-        end_timer!(t_opening_points);
 
+        let (w_comm, w_at_zeta) = aggregate_claims_multiexp(commitments, register_evals, &challenges.nus);
+        end_timer!(t_aggregate_claims);
 
         let t_kzg_batch_opening = start_timer!(|| "batched KZG openning");
+        let opening_at_zeta = KzgOpening {
+            c: w_comm,
+            x: challenges.zeta,
+            y: w_at_zeta,
+            proof: proof.w_at_zeta_proof,
+        };
+        let opening_at_zeta_omega = KzgOpening {
+            c: r_comm,
+            x: evals_at_zeta.zeta_omega,
+            y: proof.r_zeta_omega,
+            proof: proof.r_at_zeta_omega_proof,
+        };
 
-        let (total_c, total_w) = KzgBw6::aggregate_openings(&self.kzg_pvk,
-                                                            &[w_comm, r_comm],
-                                                            &[challenges.zeta, evals_at_zeta.zeta_omega],
-                                                            &[w_at_zeta, proof.r_zeta_omega],
-                                                            &[proof.w_at_zeta_proof, proof.r_at_zeta_omega_proof],
-                                                            fsrng,
-        );
-        assert!(KzgBw6::batch_check_aggregated(&self.kzg_pvk, total_c, total_w));
+        assert!(NewKzgBw6::verify_batch(vec![opening_at_zeta, opening_at_zeta_omega], &self.kzg_pvk, fsrng));
         end_timer!(t_kzg_batch_opening);
 
-
-        let t_lazy_subgroup_checks = start_timer!(|| "lazy subgroup check");
-        assert!(endo::subgroup_check(&total_c));
-        assert!(endo::subgroup_check(&total_w));
-        end_timer!(t_lazy_subgroup_checks);
+        // TODO:
+        // let t_lazy_subgroup_checks = start_timer!(|| "lazy subgroup check");
+        // assert!(endo::subgroup_check(&total_c));
+        // assert!(endo::subgroup_check(&total_w));
+        // end_timer!(t_lazy_subgroup_checks);
         end_timer!(t_kzg);
     }
 
-    fn restore_challenges<E, C, AC>(&self, public_input: &impl PublicInput, proof: &Proof<E, C, AC>) -> (Challenges, TranscriptRng)
+    fn restore_challenges<E, C, AC>(&self, public_input: &impl PublicInput, proof: &Proof<E, C, AC>, batch_size: usize) -> (Challenges, TranscriptRng)
         where
             AC: RegisterCommitments,
             C: RegisterCommitments,
@@ -193,12 +196,12 @@ impl Verifier {
         transcript.append_quotient_commitment(&proof.q_comm);
         let zeta = transcript.get_evaluation_point();
         transcript.append_evaluations(&proof.register_evaluations, &proof.q_zeta, &proof.r_zeta_omega);
-        let nu = transcript.get_kzg_aggregation_challenge();
-        (Challenges { r, phi, zeta, nu }, fiat_shamir_rng(&mut transcript))
+        let nus = transcript.get_kzg_aggregation_challenges(batch_size);
+        (Challenges { r, phi, zeta, nus }, fiat_shamir_rng(&mut transcript))
     }
 
     pub fn new(
-        kzg_vk: VerifierKey<BW6_761>,
+        kzg_vk: RawKzgVerifierKey<BW6_761>,
         pks_comm: KeysetCommitment,
         mut empty_transcript: Transcript,
     ) -> Self {

--- a/bw6/src/verifier.rs
+++ b/bw6/src/verifier.rs
@@ -41,7 +41,7 @@ impl Verifier {
         proof: &SimpleProof,
     ) -> bool {
         assert_eq!(public_input.bitmask.size(), self.pks_comm.keyset_size);
-        let (challenges, mut fsrng) = self.restore_challenges(public_input, proof, 5);
+        let (challenges, mut fsrng) = self.restore_challenges(public_input, proof, AffineAdditionEvaluations::POLYS_OPENED_AT_ZETA);
         let evals_at_zeta = utils::lagrange_evaluations(challenges.zeta, self.domain);
 
         let t_linear_accountability = start_timer!(|| "linear accountability check");
@@ -73,7 +73,7 @@ impl Verifier {
         proof: &PackedProof,
     ) -> bool {
         assert_eq!(public_input.bitmask.size(), self.pks_comm.keyset_size);
-        let (challenges, mut fsrng) = self.restore_challenges(public_input, proof, 8);
+        let (challenges, mut fsrng) = self.restore_challenges(public_input, proof, SuccinctAccountableRegisterEvaluations::POLYS_OPENED_AT_ZETA);
         let evals_at_zeta = utils::lagrange_evaluations(challenges.zeta, self.domain);
 
         self.validate_evaluations::<
@@ -95,7 +95,7 @@ impl Verifier {
         proof: &CountingProof,
     ) -> bool {
         assert!(public_input.count > 0);
-        let (challenges, mut fsrng) = self.restore_challenges(public_input, proof, 7);
+        let (challenges, mut fsrng) = self.restore_challenges(public_input, proof, CountingEvaluations::POLYS_OPENED_AT_ZETA);
         let evals_at_zeta = utils::lagrange_evaluations(challenges.zeta, self.domain);
         let count = Fr::from(public_input.count as u16);
 
@@ -152,6 +152,8 @@ impl Verifier {
         // ...together with the corresponding values
         let mut register_evals = proof.register_evaluations.as_vec();
         register_evals.push(proof.q_zeta);
+        assert_eq!(commitments.len(), challenges.nus.len());
+        assert_eq!(register_evals.len(), challenges.nus.len());
         let (w_comm, w_at_zeta) = aggregate_claims_multiexp(commitments, register_evals, &challenges.nus);
         end_timer!(t_aggregate_claims);
 


### PR DESCRIPTION
Critical things:
1. ~~get subgroup checks back~~
2. how to generate an array of 128-bit field elements with merlin
3. Merlin's fsrng is also suspicious

On fflonk side:
1. make commitment affine
2. try remove generic params from keys
3. do subgroup checks?
4. get prepared vk back

Also:
 - remove mod kzg
 - get back some stupid checks of urs size
