### PR TITLE
Lighter keyset commitment

### DIFF
--- a/bw6/src/keyset.rs
+++ b/bw6/src/keyset.rs
@@ -33,8 +33,8 @@ use crate::domains::Domains;
 pub struct KeysetCommitment {
     // Per-coordinate KZG commitments to a vector of BLS public keys on BLS12-377 represented in affine.
     pub pks_comm: (ark_bw6_761::G1Affine, ark_bw6_761::G1Affine),
-    // Domain used to interpolate the vectors above.
-    pub domain: Radix2EvaluationDomain<Fr>, // could be defined by it's generator
+    // Determines domain used to interpolate the vectors above.
+    pub log_domain_size: u32,
     // Number of 'real' public keys in the vector ( = number of possible signers).
     pub keyset_size: usize
 }
@@ -93,7 +93,7 @@ impl Keyset {
         let pks_y_comm= NewKzgBw6::commit(kzg_pk, &self.pks_polys[1]).0;
         KeysetCommitment {
             pks_comm: (pks_x_comm, pks_y_comm),
-            domain: self.domain,
+            log_domain_size: self.domain.log_size_of_group,
             keyset_size: self.pks.len(),
         }
     }

--- a/bw6/src/keyset.rs
+++ b/bw6/src/keyset.rs
@@ -35,8 +35,6 @@ pub struct KeysetCommitment {
     pub pks_comm: (ark_bw6_761::G1Affine, ark_bw6_761::G1Affine),
     // Determines domain used to interpolate the vectors above.
     pub log_domain_size: u32,
-    // Number of 'real' public keys in the vector ( = number of possible signers).
-    pub keyset_size: usize
 }
 
 #[derive(Clone)]
@@ -94,7 +92,6 @@ impl Keyset {
         KeysetCommitment {
             pks_comm: (pks_x_comm, pks_y_comm),
             log_domain_size: self.domain.log_size_of_group,
-            keyset_size: self.pks.len(),
         }
     }
 

--- a/bw6/src/verifier.rs
+++ b/bw6/src/verifier.rs
@@ -40,7 +40,6 @@ impl Verifier {
         public_input: &AccountablePublicInput,
         proof: &SimpleProof,
     ) -> bool {
-        assert_eq!(public_input.bitmask.size(), self.pks_comm.keyset_size);
         let (challenges, mut fsrng) = self.restore_challenges(public_input, proof, AffineAdditionEvaluations::POLYS_OPENED_AT_ZETA);
         let evals_at_zeta = utils::lagrange_evaluations(challenges.zeta, self.domain);
 
@@ -72,7 +71,6 @@ impl Verifier {
         public_input: &AccountablePublicInput,
         proof: &PackedProof,
     ) -> bool {
-        assert_eq!(public_input.bitmask.size(), self.pks_comm.keyset_size);
         let (challenges, mut fsrng) = self.restore_challenges(public_input, proof, SuccinctAccountableRegisterEvaluations::POLYS_OPENED_AT_ZETA);
         let evals_at_zeta = utils::lagrange_evaluations(challenges.zeta, self.domain);
 


### PR DESCRIPTION
Full domain object in KeysetCommitment replaced by log_domain_size: u32 that uniquely determines the domain. Also keyset_size removed. That makes the 'counting' scheme not really useful, but who cares.